### PR TITLE
Add `update_cholesky()` method

### DIFF
--- a/kern_gp/__init__.py
+++ b/kern_gp/__init__.py
@@ -66,3 +66,20 @@ def _complexity(L, a):
     log_det_L = -jnp.sum(jnp.log(jnp.diag(L)))  # because we use cholesky, the factor of 2 cancels so no -1/2
     a_adjustment = -jnp.log(a) * L.shape[0] / 2
     return log_det_L + a_adjustment
+
+
+def update_cholesky(L, k_new, k_new_new):
+    """Efficiently update Cholesky factor given a new obervation"""
+    
+    v = solve_triangular(L, k_new, lower=True)
+    
+    # Calculate the new diagonal element
+    s = jnp.sqrt(k_new_new - jnp.sum(v**2))
+    
+    # Form the new Cholesky factor
+    n = L.shape[0]
+    top_block = jnp.concatenate([L, jnp.zeros((n, 1))], axis=1)
+    bottom_row = jnp.concatenate([v, jnp.array([s])])
+    L_new = jnp.concatenate([top_block, bottom_row.reshape(1, n+1)], axis=0)
+    
+    return L_new

--- a/kern_gp/__init__.py
+++ b/kern_gp/__init__.py
@@ -68,13 +68,13 @@ def _complexity(L, a):
     return log_det_L + a_adjustment
 
 
-def update_cholesky(L, k_new, k_new_new):
+def update_cholesky(L, k_new_row, k_new_diag):
     """Efficiently update Cholesky factor given a new obervation"""
     
-    v = solve_triangular(L, k_new, lower=True)
+    v = solve_triangular(L, k_new_row, lower=True)
     
     # Calculate the new diagonal element
-    s = jnp.sqrt(k_new_new - jnp.sum(v**2))
+    s = jnp.sqrt(k_new_diag - jnp.sum(v**2))
     
     # Form the new Cholesky factor
     n = L.shape[0]

--- a/test_kern_gp.py
+++ b/test_kern_gp.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import torch
 
-from kern_gp import mll_train, noiseless_predict
+from kern_gp import mll_train, noiseless_predict, _k_cholesky
 
 X_train = jnp.array([[1, 2, 3], [4, 5, 6]]) / 5
 y_train = jnp.array([0.5, 1.0])
@@ -92,3 +92,36 @@ def test_noiseless_predict(outputscale, noise, full_covar):
     # Test: are they close?
     assert jnp.allclose(mu_true, our_mu)
     assert jnp.allclose(covar_true, our_covar, rtol=1e-5)
+
+
+def test_update_cholesky():
+    # Create a simple kernel matrix
+    K = jnp.array([
+        [1.0, 0.5, 0.3],
+        [0.5, 1.0, 0.2],
+        [0.3, 0.2, 1.0]
+    ])
+    noise = 0.1
+    
+    # Compute the Cholesky decomposition
+    L = _k_cholesky(K, noise)
+    
+    # New data point
+    k_new = jnp.array([0.4, 0.6, 0.1])  # Similarities to existing points
+    k_new_new = 1.0                     # Self-similarity of new point
+    
+    # Update the Cholesky
+    L_updated = kgp.update_cholesky(L, k_new, k_new_new)
+    
+    # Build the updated kernel matrix
+    K_new = jnp.zeros((4, 4))
+    K_new = K_new.at[:3, :3].set(K)
+    K_new = K_new.at[:3, 3].set(k_new)
+    K_new = K_new.at[3, :3].set(k_new)
+    K_new = K_new.at[3, 3].set(k_new_new)
+    
+    # Compute the Cholesky from scratch for comparison
+    L_expected = jnp.linalg.cholesky(K_new)
+    
+    # Test: are they close?
+    assert jnp.allclose(L_updated, L_expected, rtol=1e-5)


### PR DESCRIPTION
This PR implements the `update_cholesky()` method, which efficiently updates the Cholesky factor given a new observation:

```py
def update_cholesky(L, k_new, k_new_new):
    """Efficiently update Cholesky factor given a new obervation"""
    
    v = solve_triangular(L, k_new, lower=True)
    
    # Calculate the new diagonal element
    s = jnp.sqrt(k_new_new - jnp.sum(v**2))
    
    # Form the new Cholesky factor
    n = L.shape[0]
    top_block = jnp.concatenate([L, jnp.zeros((n, 1))], axis=1)
    bottom_row = jnp.concatenate([v, jnp.array([s])])
    L_new = jnp.concatenate([top_block, bottom_row.reshape(1, n+1)], axis=0)
    
    return L_new
```

This is referenced by the `tanimoto_gp` library in the `add_observation()` method:
```py
# If we have cached L, update it efficiently
if self._L_cached is not None:
      a = TRANSFORM(params.raw_amplitude)
      s = TRANSFORM(params.raw_noise)
      self._L_cached = kgp.update_cholesky(
          self._L_cached,
          k_new,
          k_new_new + (s/a)
      )
```
The above changes to `tanimoto_gp` are reflected in AustinT/tanimoto-gp#3.